### PR TITLE
Man avg feature

### DIFF
--- a/src/AdcircSubgrid/preprocessor.py
+++ b/src/AdcircSubgrid/preprocessor.py
@@ -274,6 +274,7 @@ class SubgridPreprocessor:
                     result["c_f"],
                     result["c_bf"],
                     result["c_adv"],
+                    result["man_avg"],
                 )
 
             progress.increment()
@@ -496,6 +497,10 @@ class SubgridPreprocessor:
             subset_data["data"]["manning_n"], SubgridPreprocessor.DRY_PIXEL_WATER_DEPTH
         )
 
+        man_avg = SubgridPreprocessor.__compute_man_avg(
+            subset_data["data"]["manning_n"]
+        )
+
         cf, cf_avg = self.__compute_cf_at_levels(
             depth_info["depth"],
             subset_data["data"]["manning_n"],
@@ -530,6 +535,7 @@ class SubgridPreprocessor:
             "c_f": cf_avg,
             "c_adv": c_adv,
             "c_bf": c_bf,
+            "man_avg": man_avg
         }
 
     @staticmethod
@@ -638,6 +644,21 @@ class SubgridPreprocessor:
             The default friction coefficient
         """
         return g_constant * np.nanmean(manning**2) / dry_pixel_depth ** (1.0 / 3.0)
+    
+    @staticmethod
+    @njit
+    def __compute_man_avg(manning: np.ndarray) -> float:
+        """
+        Compute the grid averaged Manning's n values
+
+        Args:
+            manning: The Manning's n values
+        
+        Returns:
+            The grid averaged Manning's n for a vertex area
+        """
+
+        return np.nanmean(manning)
 
     @staticmethod
     @njit

--- a/src/AdcircSubgrid/subgrid_data.py
+++ b/src/AdcircSubgrid/subgrid_data.py
@@ -54,6 +54,7 @@ class SubgridData:
         self.__c_bf = np.zeros((self.__node_count, self.__phi_count))
         self.__c_adv = np.zeros((self.__node_count, self.__phi_count))
         self.__vertex_flag = np.zeros(self.__node_count, dtype=int)
+        self.__man_avg = np.zeros(self.__node_count)
 
     def node_count(self) -> int:
         """
@@ -153,6 +154,15 @@ class SubgridData:
             The vertex flag values
         """
         return self.__vertex_flag
+    
+    def man_avg(self) -> np.ndarray:
+        """
+        Return grid averaged Manning's n
+
+        Returns:
+            The grid averaged Manning's n value
+        """
+        return self.__man_avg
 
     def get_vertex(self, vertex: int) -> dict:
         """
@@ -177,6 +187,7 @@ class SubgridData:
             "c_f": self.__c_f[vertex],
             "c_bf": self.__c_bf[vertex],
             "c_adv": self.__c_adv[vertex],
+            "man_avg": self.__man_avg[vertex],
         }
 
     def set_data(
@@ -189,6 +200,7 @@ class SubgridData:
         c_f: np.ndarray,
         c_bf: np.ndarray,
         c_adv: np.ndarray,
+        man_avg: np.ndarray,
     ) -> None:
         """
         Set the output data for all vertices
@@ -202,6 +214,7 @@ class SubgridData:
             c_f: The quadratic friction values
             c_bf: The friction correction values
             c_adv: The advection correction values
+            man_avg: The average Manning's n values
         """
         if (
             vertex_flag.shape != (self.__node_count,)
@@ -212,6 +225,7 @@ class SubgridData:
             or c_f.shape != (self.__node_count, self.__phi_count)
             or c_bf.shape != (self.__node_count, self.__phi_count)
             or c_adv.shape != (self.__node_count, self.__phi_count)
+            or man_avg.shape != (self.__node_count)
         ):
             msg = "Invalid shape for input arrays"
             raise ValueError(msg)
@@ -224,6 +238,7 @@ class SubgridData:
         self.__c_f = c_f
         self.__c_bf = c_bf
         self.__c_adv = c_adv
+        self.__man_avg = man_avg
 
     def add_vertex(
         self,
@@ -235,6 +250,7 @@ class SubgridData:
         c_f: np.ndarray,
         c_bf: np.ndarray,
         c_adv: np.ndarray,
+        man_avg: float,
     ) -> None:
         """
         Add a vertex to the output data
@@ -248,6 +264,7 @@ class SubgridData:
             c_f: The quadratic friction values
             c_bf: The friction correction values
             c_adv: The advection correction values
+            man_avg: The average Manning's n values
         """
         # Check if the shape of the input arrays is correct
         if (
@@ -263,6 +280,7 @@ class SubgridData:
             raise ValueError(msg)
 
         self.__vertex_flag[vertex] = 1
+        self.__man_avg[vertex] = man_avg
         if self.__interpolation_method == "linear":
             self.__interp_linear(
                 vertex,

--- a/src/AdcircSubgrid/subgrid_output_file.py
+++ b/src/AdcircSubgrid/subgrid_output_file.py
@@ -55,6 +55,14 @@ class SubgridOutputFile:
             )
             phi.description = "Percent wet for the subgrid element"
 
+            manning = dataset.createVariable(
+                "man_avg", "f4", ("numNode",), zlib = True, complevel=2
+            )
+
+            manning.description = (
+                "Grid averaged manning for the vertex area"
+            )
+
             wet_fraction_elevation = dataset.createVariable(
                 "wetFractionVertex",
                 "f4",
@@ -125,6 +133,8 @@ class SubgridOutputFile:
             mask2d = mask2d == 0
 
             phi[:] = sg_data.phi()
+
+            manning[:] = sg_data.man_avg()
 
             wet_fraction_elevation_out = sg_data.water_level()
             wet_fraction_elevation_out[mask2d] = netCDF4.default_fillvals["f4"]
@@ -221,6 +231,7 @@ class SubgridOutputFile:
             c_f = dataset.variables["cfVertex"][:].data
             c_bf = dataset.variables["cmfVertex"][:].data
             c_adv = dataset.variables["cadvVertex"][:].data
+            man_avg = dataset.variables["man_avg"][:].data
 
             # Set the data in the SubgridData object
             sg_data.set_data(
@@ -232,6 +243,7 @@ class SubgridOutputFile:
                 c_f,
                 c_bf,
                 c_adv,
+                man_avg,
             )
 
         return sg_data


### PR DESCRIPTION
Allows for output of average Manning's n value for use in calculating friction coefficients on fully wet nodes in the sub grid region. This prevents the over estimation of bottom friction in these regions. 